### PR TITLE
Align curriculum documentation with A²I program design conversation

### DIFF
--- a/docs/curriculum/core_courses.md
+++ b/docs/curriculum/core_courses.md
@@ -1,72 +1,39 @@
-# Core Courses
+# Core Courses (A²I 601–606)
 
-## Course Sequence
+The six-course core sequence establishes the shared mindset and toolkit required to orchestrate intelligent systems responsibly. Each 8-week course blends Coursera media, Canvas discussions, applied projects, oral vivas, and AI-augmented feedback.【F:docs/context/conversation.md†L44-L108】
 
-### Year 1: Foundations
+## A²I 601 – AI Strategy & Problem Framing
+- Position AI initiatives within organizational missions and stakeholder needs.
+- Diagnose coherence gaps across data, workflows, and governance.
+- Practice strategic narrative framing and portfolio prioritization.
 
-#### Introduction to AI and Machine Learning
-- AI fundamentals and history
-- Machine learning basics
-- Python for AI/ML
-- Introduction to data science
+## A²I 602 – Data & AI Infrastructure
+- Design inclusive data architectures leveraging Google Cloud services.
+- Establish observability, lineage, and data quality metrics.
+- Integrate privacy, security, and accessibility into infrastructure decisions.
 
-#### Data Structures and Algorithms
-- Algorithm design and analysis
-- Data structures for ML applications
-- Computational complexity
-- Problem-solving techniques
+## A²I 603 – Evidence & Causality
+- Apply experimental and quasi-experimental methods for trustworthy inference.
+- Evaluate bias, fairness, and differential impact across populations.
+- Interpret causal evidence to guide iterative product decisions.
 
-#### Mathematics for AI
-- Linear algebra
-- Calculus
-- Probability and statistics
-- Optimization
+## A²I 604 – Predictive & Prescriptive AI
+- Operationalize predictive models alongside prescriptive optimization.
+- Balance automation with human judgment in complex workflows.
+- Align AI interventions with sustainable value and mission outcomes.
 
-### Year 2: Advanced Topics
+## A²I 605 – Intelligent Agents & Workflows
+- Architect agentic systems for automation, augmentation, and collaboration.
+- Map human-in-the-loop controls, escalation paths, and safety guardrails.
+- Prototype multi-agent workflows that demonstrate reliability and coherence.
 
-#### Deep Learning
-- Neural networks
-- Convolutional networks
-- Recurrent networks
-- Transformers and attention mechanisms
+## A²I 606 – Governance & Trust Systems
+- Translate regulatory, ethical, and institutional requirements into design constraints.
+- Develop accountability frameworks, audit trails, and compliance dashboards.
+- Facilitate cross-functional governance rituals and reflective practice.
 
-#### Natural Language Processing
-- Text processing and analysis
-- Language models
-- Semantic understanding
-- NLP applications
-
-#### Computer Vision
-- Image processing
-- Object detection and recognition
-- Scene understanding
-- Visual AI applications
-
-### Year 3: Specialization
-
-#### Reinforcement Learning
-- MDP foundations
-- Q-learning and policy gradients
-- Deep reinforcement learning
-- Real-world applications
-
-#### AI Ethics and Society
-- Ethical frameworks
-- Bias and fairness
-- Privacy and security
-- Societal impact
-
-#### Advanced Topics Seminar
-- Emerging AI technologies
-- Research methods
-- Guest speakers from industry
-- Current challenges and opportunities
-
-## Course Format
-
-Each course includes:
-- Lectures (online and in-person)
-- Hands-on labs
-- Problem sets
-- Projects
-- AI-assisted learning support
+### Shared Core Expectations
+- **Applied Projects (50%)** – Learners deliver artifacts that evidence coherent system design.
+- **Auto-Checks (20%)** – Automated assessments reinforce foundational knowledge.
+- **Oral Vivas (20%)** – Week 8 dialogues surface judgment, reflection, and integrity.
+- **Peer Critique (10%)** – Cyber-social review develops evaluative and coaching skills.【F:docs/context/conversation.md†L80-L108】

--- a/docs/curriculum/electives.md
+++ b/docs/curriculum/electives.md
@@ -1,96 +1,52 @@
-# Electives
+# Electives & Domain Tracks
 
-## Overview
+## Purpose
 
-Electives allow students to customize their learning path based on interests and career goals.
+Electives deepen expertise within mission-driven domains so learners can translate core orchestration skills into sector-specific impact. Offerings evolve through open contribution but are organized around three anchor tracks identified in the founding conversation.【F:docs/context/conversation.md†L129-L137】
 
-## Available Electives
+## Track Overview
 
-### Technical Electives
+### Growth for Good
+Focuses on equitable experimentation, ethical marketing, and customer journeys that prioritize inclusion and trust.
 
-#### Advanced Machine Learning
-- Ensemble methods
-- Transfer learning
-- Meta-learning
-- AutoML
+**Sample Electives**
+- Responsible Growth Analytics (experiment design for inclusive outcomes)
+- Human-Centered Marketing Automation (journey orchestration with guardrails)
+- Social Impact Metrics Studio (measuring mission-aligned value)
 
-#### AI Systems Engineering
-- ML ops and deployment
-- Model serving at scale
-- Monitoring and maintenance
-- Production ML systems
+### Finance for Inclusion
+Equips learners to design financial systems that expand access while maintaining compliance and risk controls.
 
-#### Robotics and Embodied AI
-- Robot perception
-- Motion planning
-- Human-robot interaction
-- Autonomous systems
+**Sample Electives**
+- Inclusive Credit & Risk Modeling (alternative data, fairness audits)
+- RegTech & Compliance Automation (governance workflows across regulators)
+- Financial Resilience Analytics (forecasting and stress testing for underserved communities)
 
-#### Generative AI
-- GANs and VAEs
-- Diffusion models
-- Large language models
-- Creative AI applications
+### Healthcare for Humanity
+Centers on access, outcomes, and ethical deployment of intelligent systems in health contexts.
 
-#### Quantum Computing for AI
-- Quantum fundamentals
-- Quantum algorithms
-- Quantum ML
-- Near-term applications
+**Sample Electives**
+- Care Pathway Intelligence (workflow orchestration across clinicians and agents)
+- Health Data Cooperatives (governance models for community-owned data)
+- Responsible Diagnostics & Triage (evaluation frameworks for clinical agents)
 
-### Domain-Specific Electives
+## Entrepreneurship Integration
 
-#### AI for Healthcare
-- Medical imaging
-- Clinical decision support
-- Drug discovery
-- Healthcare analytics
+- **A²I 643 – Venture Creation in Intelligent Systems:** Required for learners pursuing the venture capstone path; covers opportunity assessment, lean experimentation, funding models, and go-to-market strategy.【F:docs/context/conversation.md†L157-L177】
+- Domain tracks collaborate with the iVenture Accelerator, Origin Ventures Office, and industry mentors to incubate new ventures and partnerships.
 
-#### AI for Finance
-- Algorithmic trading
-- Risk assessment
-- Fraud detection
-- Financial forecasting
+## Elective Experience
 
-#### AI for Climate and Sustainability
-- Environmental monitoring
-- Climate modeling
-- Resource optimization
-- Sustainable systems
+- 8-week modules aligned with the Canvas template, integrating Coursera content, applied assignments, and oral vivas.
+- Cross-track studios encourage interdisciplinary teams tackling shared challenges.
+- Open GitHub repositories capture syllabi, artifacts, and evaluation rubrics for community iteration.
 
-#### AI for Education
-- Adaptive learning systems
-- Educational data mining
-- Intelligent tutoring
-- Learning analytics
+## Proposing New Electives
 
-### Cross-Disciplinary Electives
+Community members may suggest additions via the curriculum governance process. Proposals should specify:
+- Domain alignment and stakeholder need.
+- How the course reinforces coherence, governance, and inclusion.
+- Required partnerships (industry, civic, research) and resource implications.
+- Assessment strategy leveraging AI-augmented feedback.
 
-#### AI and Law
-- AI regulation
-- Intellectual property
-- Liability and responsibility
-- Legal applications of AI
-
-#### AI and Design
-- Human-centered AI
-- UX for AI systems
-- Design thinking
-- Creative applications
-
-#### AI and Business
-- AI strategy
-- Business transformation
-- AI product management
-- Value creation
-
-## Elective Format
-
-- Typically 4-6 week intensive courses
-- Mix of lectures, readings, and projects
-- Guest speakers from industry and academia
-- Practical, application-focused
-
-## Adding New Electives
-
-The curriculum is designed to evolve. New electives can be proposed through the curriculum update process. See [CONTRIBUTING.md](../../CONTRIBUTING.md) for details.
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for submission guidelines.

--- a/docs/curriculum/labs_and_capstone.md
+++ b/docs/curriculum/labs_and_capstone.md
@@ -1,75 +1,52 @@
-# Labs and Capstone
+# Studios and Capstone
 
-## Labs
+## Applied Studios (A²I 621–623)
 
-### Lab Structure
+Each studio is an 8-week, project-intensive experience that immerses learners in the practice of orchestrating intelligent systems on Google Cloud infrastructure with open collaboration in GitHub.【F:docs/context/conversation.md†L56-L124】
 
-Each core course is accompanied by hands-on labs that reinforce theoretical concepts through practical application.
+### A²I 621 – Analytics Engineering Studio
+- Build inclusive data pipelines and semantic layers in BigQuery and Looker.
+- Operationalize data quality checks, lineage, and access policies.
+- Deliver reproducible analytics artifacts ready for enterprise deployment.
 
-#### Lab Components
-- Guided exercises
-- Open-ended challenges
-- Real-world datasets
-- Industry-relevant tools and frameworks
+### A²I 622 – Data Product Studio
+- Translate opportunity statements into deployable AI products.
+- Prototype services using Vertex AI, managed APIs, and automation frameworks.
+- Conduct peer and stakeholder reviews emphasizing coherence and value realization.
 
-#### Lab Infrastructure
-- Google Cloud Platform
-- Jupyter notebooks
-- Version control with Git/GitHub
-- Collaborative development environments
+### A²I 623 – Agent Ops & Evaluation Studio
+- Evaluate agentic workflows for reliability, safety, and guardrail coverage.
+- Implement evaluation harnesses, red-teaming rituals, and observability dashboards.
+- Document human-in-the-loop protocols and escalation procedures.
 
-### Example Labs
+### Studio Experience
+- Weekly design reviews and peer critique circles.
+- Shared telemetry dashboards to surface progress and risks.
+- Integration with Canvas oral vivas and AI-augmented coaching.
 
-1. **ML Fundamentals Lab**: Build and train basic ML models
-2. **Deep Learning Lab**: Implement neural networks from scratch
-3. **NLP Lab**: Create text processing pipelines
-4. **Computer Vision Lab**: Build image classification systems
-5. **RL Lab**: Train agents in simulated environments
+## Capstone (A²I 699 – Intelligent Systems for Public Value)
 
-## Capstone Project
+### Purpose
+Learners synthesize program threads by delivering an authentic system that advances public or organizational value while demonstrating governance, entrepreneurship, and reflexive practice.【F:docs/context/conversation.md†L135-L177】
 
-### Overview
+### Tracks
+1. **Systems Integration Project** – Partner with an organization to orchestrate data, agents, and human teams into a coherent workflow.
+2. **Venture Launch Project** – Pursue a startup concept supported by the iVenture Accelerator, culminating in a public demo and venture plan.
 
-The capstone project is a semester-long (or year-long) project where students apply their knowledge to solve a real-world problem.
+### Core Requirements
+- Formal proposal and stakeholder charter by Week 2.
+- Iterative build logs and observability dashboards reviewed bi-weekly.
+- Week 8 viva with faculty, peers, and external advisors.
+- Public artifact (whitepaper, product, or policy playbook) licensed for community learning.
 
-### Requirements
+### Support Ecosystem
+- Faculty mentors with governance, technical, and venture expertise.
+- Industry advisors aligned with the program’s domain tracks.
+- Access to Google Cloud resources, GitHub Actions automation, and AI tooling.
+- Integration with entrepreneurship programming (Origin Ventures Office, iVenture, Strategy & Innovation faculty).
 
-- Identify a meaningful problem
-- Design and implement an AI solution
-- Evaluate performance and impact
-- Present findings to stakeholders
-- Document the entire process
-
-### Project Types
-
-1. **Research Projects**: Novel approaches to AI challenges
-2. **Application Projects**: Practical solutions to real problems
-3. **Entrepreneurial Projects**: Viable products or services
-4. **Social Impact Projects**: AI for good initiatives
-
-### Capstone Support
-
-- Faculty advisors
-- Industry mentors
-- Peer collaboration
-- AI-assisted development tools
-- Access to computing resources
-
-### Deliverables
-
-- Project proposal
-- Progress reports
-- Final implementation
-- Technical documentation
-- Presentation and demo
-- Reflection paper
-
-## Assessment
-
-Labs and capstone are assessed on:
-- Technical execution
-- Innovation and creativity
-- Real-world applicability
-- Documentation quality
-- Presentation and communication
-- Ethical considerations
+### Assessment Alignment
+- **Applied Impact (40%)** – Demonstrated value, alignment with mission, and stakeholder adoption.
+- **Governance & Trust (25%)** – Clarity of controls, accountability, and ethical considerations.
+- **Technical & Operational Excellence (20%)** – Reliability, observability, and integration quality.
+- **Reflection & Leadership (15%)** – Viva performance, reflective essays, and peer feedback contributions.

--- a/docs/curriculum/learning_outcomes.md
+++ b/docs/curriculum/learning_outcomes.md
@@ -2,82 +2,37 @@
 
 ## Program-Level Outcomes
 
-Upon completion of the A2I curriculum, students will be able to:
+Graduates of the A²I program orchestrate intelligent systems that advance organizational and public missions with integrity. Upon completion, learners will be able to:
 
-### Technical Competencies
+### Coherent Systems Leadership
+1. **Frame and Prioritize AI Portfolios** – Align opportunities with institutional purpose, stakeholder value, and measurable outcomes.【F:docs/context/conversation.md†L16-L108】
+2. **Coordinate Human–AI Workflows** – Design multi-agent processes that integrate automation, augmentation, and human oversight for reliable delivery.【F:docs/context/conversation.md†L100-L138】
+3. **Operationalize Governance and Trust** – Embed accountability, compliance, and ethics throughout data, model, and workflow lifecycles.【F:docs/context/conversation.md†L104-L176】
 
-1. **Design and Implement AI Systems**
-   - Develop machine learning models for various applications
-   - Build end-to-end AI systems from data to deployment
-   - Select appropriate algorithms and architectures for specific problems
+### Evidence & Infrastructure
+4. **Engineer Reflexive Data Ecosystems** – Build inclusive data pipelines, observability dashboards, and feedback mechanisms on cloud platforms to sustain quality and learning.【F:docs/context/conversation.md†L56-L124】
+5. **Generate and Interpret Causal Evidence** – Apply experimental design, fairness evaluation, and causal reasoning to validate system impact.【F:docs/context/conversation.md†L100-L119】
+6. **Measure Mission-Critical Value** – Define metrics that capture economic, social, and equity outcomes across domain contexts.【F:docs/context/conversation.md†L120-L154】
 
-2. **Analyze and Evaluate AI Solutions**
-   - Assess model performance using appropriate metrics
-   - Debug and optimize AI systems
-   - Conduct rigorous experiments and evaluations
+### Reflexive Practice & Entrepreneurship
+7. **Lead Reflexive Learning Communities** – Facilitate peer critique, AI-augmented feedback loops, and public documentation that model transparent, cyber-social learning.【F:docs/context/conversation.md†L179-L214】
+8. **Activate Entrepreneurial Innovation** – Translate insights into ventures or change initiatives supported by the Gies entrepreneurship ecosystem.【F:docs/context/conversation.md†L157-L177】
+9. **Champion Access & Inclusion** – Design curricula, products, and governance practices that widen participation and reduce bias in alignment with UIUC’s mission.【F:docs/context/conversation.md†L140-L154】
 
-3. **Work with Data**
-   - Collect, clean, and preprocess data
-   - Perform exploratory data analysis
-   - Handle large-scale datasets efficiently
+## Course Alignment
 
-4. **Deploy AI in Production**
-   - Implement scalable ML systems
-   - Monitor and maintain deployed models
-   - Handle real-world constraints and requirements
+Each core course, studio, and elective documents specific outcomes that map back to these program competencies. Course-level matrices live alongside syllabi within the curriculum repository for iterative improvement.
 
-### Ethical and Professional Skills
+## Assessment Approach
 
-5. **Apply Ethical Frameworks**
-   - Identify ethical issues in AI systems
-   - Apply fairness and bias mitigation techniques
-   - Consider societal impact in design decisions
+Learning outcomes are evidenced through:
+- Applied projects, labs, and studio artifacts (50%).
+- Automated knowledge checks and analytics dashboards (20%).
+- Oral vivas and reflective essays (20%).
+- Peer critique and community contribution (10%).【F:docs/context/conversation.md†L80-L108】
 
-6. **Communicate Effectively**
-   - Explain technical concepts to non-technical audiences
-   - Document systems and decisions clearly
-   - Present findings and recommendations
-
-7. **Collaborate in Teams**
-   - Work effectively in diverse teams
-   - Use collaborative development tools
-   - Give and receive constructive feedback
-
-### Innovation and Entrepreneurship
-
-8. **Identify Opportunities**
-   - Recognize problems that AI can address
-   - Evaluate feasibility and impact
-   - Design innovative solutions
-
-9. **Create Value**
-   - Build prototypes and MVPs
-   - Validate ideas with users
-   - Understand business and market considerations
-
-10. **Navigate Uncertainty**
-    - Adapt to rapidly changing technology
-    - Learn new tools and techniques independently
-    - Embrace experimentation and iteration
-
-## Course-Specific Outcomes
-
-Each course has detailed learning outcomes that map to these program-level outcomes. See individual course documentation for details.
-
-## Assessment
-
-Learning outcomes are assessed through:
-- Projects and labs
-- Problem sets and exams
-- Capstone project
-- Portfolio of work
-- Peer and self-assessment
-- AI-augmented feedback
+Capstone evaluations integrate impact, governance, technical excellence, and leadership dimensions to ensure coherence across program threads.【F:docs/context/conversation.md†L135-L177】
 
 ## Continuous Improvement
 
-Learning outcomes are reviewed and updated regularly based on:
-- Student feedback
-- Industry needs
-- Technological advances
-- Educational research
+Outcomes undergo review during monthly governance rituals and quarterly roadmap checkpoints, incorporating feedback from students, faculty, industry advisors, and the broader community. Updates reference the living conversation history to maintain alignment with the founding vision.【F:docs/context/conversation.md†L9-L22】【F:docs/context/conversation.md†L214-L230】

--- a/docs/curriculum/overview.md
+++ b/docs/curriculum/overview.md
@@ -2,35 +2,39 @@
 
 ## Vision
 
-The AI for Innovation (A2I) curriculum prepares students to become ethical, innovative leaders in the AI-driven economy through hands-on learning, real-world projects, and entrepreneurial thinking.
+The Master of Science in Applied Artificial Intelligence and Business Systems (A²I) develops **system orchestrators** who can align people, data, and intelligent agents toward verifiable business and societal value. The program embraces the insight that *capability is cheap; coherence is scarce* and therefore focuses on leadership, governance, and reflexive learning with AI.【F:docs/context/conversation.md†L1-L138】
 
 ## Program Structure
 
+- **Credits & Cadence:** 36 credits delivered across twelve 8-week courses designed for working professionals. Every course follows a shared Canvas template with Week 0 orientation, Weeks 1–8 learning cycles, and Week 8 viva and reflection.【F:docs/context/conversation.md†L44-L92】
+- **Delivery Ecosystem:** Coursera scales asynchronous content, Canvas anchors graded and synchronous elements, Google Cloud powers labs, and GitHub houses the open development repository for transparency.【F:docs/context/conversation.md†L56-L76】
+
 ### Core Courses
-Foundational knowledge in AI, machine learning, and related technologies.
+Six foundational courses (A²I 601–606) establish shared literacy in strategy, infrastructure, causality, intelligent workflows, and governance.【F:docs/context/conversation.md†L94-L119】
 
-### Labs & Capstone
-Practical, project-based learning culminating in a capstone project.
+### Studios & Capstone
+Three applied studios (A²I 621–623) provide hands-on practice, culminating in A²I 699 where students integrate systems for public value or launch ventures.【F:docs/context/conversation.md†L121-L155】
 
-### Electives
-Specialized topics allowing students to customize their learning path.
+### Domain Tracks & Electives
+Electives are organized into mission-driven tracks—Growth for Good, Finance for Inclusion, and Healthcare for Humanity—so learners can contextualize core capabilities in high-impact domains.【F:docs/context/conversation.md†L129-L137】
 
-### Venture Creation
-Entrepreneurship course and innovation studio for building AI-powered solutions.
+### Entrepreneurship Thread
+Entrepreneurship is woven throughout via the venture creation elective (A²I 643), iVenture Accelerator support, and modules on opportunity recognition, funding, and commercialization.【F:docs/context/conversation.md†L157-L177】
 
 ## Learning Philosophy
 
-The curriculum is built on:
-- **Reflexive Learning**: Continuous reflection and adaptation
-- **Cyber-Social Learning**: Collaborative, technology-enhanced learning
-- **AI-Augmented Education**: Leveraging AI for feedback and assessment
-- **Practice-Based**: Learning by doing with real-world applications
+The learning model blends reflexive, cyber-social, and AI-augmented pedagogy:
 
-## Delivery
+- **Reflexive Learning:** Students co-create knowledge artifacts, critique platforms, and reflect on the systems they build.【F:docs/context/conversation.md†L179-L214】
+- **Cyber-Social Learning:** Human ↔ AI ↔ peer feedback loops sustain continuous improvement and transparency.【F:docs/context/conversation.md†L207-L214】
+- **AI as Cognitive Partner:** Intelligent tools provide formative assessment, analytics, and coaching rather than policing compliance.【F:docs/context/conversation.md†L197-L205】
+- **Practice-Based:** Every course centers on applied projects, oral vivas, and peer critique to demonstrate coherent outcomes.【F:docs/context/conversation.md†L80-L108】
 
-- Primary platform: Canvas LMS
-- Public courses: Coursera
-- Technical infrastructure: Google Cloud
-- Open development: GitHub
+## Delivery Infrastructure
 
-See detailed documentation in the respective sections.
+- **Canvas LMS:** Hosts assessments, peer review, and oral vivas.
+- **Coursera:** Delivers scalable asynchronous media.
+- **Google Cloud Platform:** Provides BigQuery, Vertex AI, and Looker lab environments.
+- **GitHub:** Maintains open curriculum development and documentation workflows.【F:docs/context/conversation.md†L56-L76】
+
+Consult the detailed curriculum, pedagogy, and platform sections for course-level information.


### PR DESCRIPTION
## Summary
- update the curriculum overview to reflect the 36-credit, 8-week program architecture articulated in the founding conversation
- rewrite the core courses, studios, electives, and learning outcomes to align with the A²I course codes, domains, and governance themes captured in docs/context/conversation.md
- embed entrepreneurship, governance, and reflexive pedagogy threads throughout the curriculum documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_690607e87aec8320807a19af06d7d618